### PR TITLE
Workaround to upload files >2GB in size 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 requests
+requests-toolbelt

--- a/seafileapi/client.py
+++ b/seafileapi/client.py
@@ -82,17 +82,6 @@ class SeafileApiClient(object):
 
         return resp
 
-def read_in_chunks(path):
-    # If you're going to chunk anyway, doesn't it seem like smaller ones than this would be a good idea?
-    chunk_size = 30720 * 30720
-    # I don't know how correct this is; if it doesn't work as expected, you'll need to debug
-    with open(path, 'rb') as file_object:
-        while True:
-            data = file_object.read(chunk_size)
-            if not data:
-                break
-            yield data
-
 
 class Groups(object):
     def __init__(self, client):

--- a/seafileapi/files.py
+++ b/seafileapi/files.py
@@ -185,7 +185,7 @@ class SeafDir(_SeafDirentBase):
         Return a :class:`SeafFile` object of the newly uploaded file.
         """
         name = name or os.path.basename(filepath)
-        with open(filepath, 'r') as fp:
+        with open(filepath, 'rb') as fp:
             return self.upload(fp, name)
 
     def _get_upload_link(self):

--- a/seafileapi/repos.py
+++ b/seafileapi/repos.py
@@ -21,6 +21,15 @@ class Repos(object):
         repo_json = self.client.get('/api2/repos/' + repo_id).json()
         return Repo.from_json(self.client, repo_json)
 
+    @raise_does_not_exist('The requested library does not exist')
+    def get_default_repo(self):
+        """Get the default repo.
+
+        Raises :exc:`DoesNotExist` if no default repo exists.
+        """
+        repo_json = self.client.get('/api2/default-repo').json()
+        return self.get_repo(repo_json['repo_id'])
+
     def list_repos(self):
         repos_json = self.client.get('/api2/repos/').json()
         return  [Repo.from_json(self.client, j) for j in repos_json]


### PR DESCRIPTION
Forked from https://github.com/tgal/python-seafile.git, which fixes the issue that uploading binary files also doesn't work. Has additional requierement requests-toolbelt because that seems to be the only way to fix the issue (see psf/requests#2717)